### PR TITLE
Bug fix to allow JNDI properties to work correctly

### DIFF
--- a/auth-commons/src/main/java/gov/usgs/cida/auth/util/JNDISingleton.java
+++ b/auth-commons/src/main/java/gov/usgs/cida/auth/util/JNDISingleton.java
@@ -23,6 +23,6 @@ public class JNDISingleton {
                 LOG.warn("Error occured during initProps()", e);
             } 
         }
-        return new DynamicReadOnlyProperties(props);
+        return props;
     }
 }


### PR DESCRIPTION
JNDI properties were not readable prior to this change, meaning that context.xml configured params could not be read.

The issue is that DynamicReadOnlyProperties (DROP) relies on an internal boolean flag to indicate if it contains JNDI values - this flag is set true when addJNDIContexts() is called.  However, as soon as one DROP instance is wrapped in a new one, that same flag is not set on the new one.  As a result, DROP does not look for expanded JNDI names.

Example:  Configure a **dev** property in the Tomcat context.xml file results in a property named something like **java:/env/dev**   If you try to read the **dev** property it will not be found unless the jndi flag is set, in which case it checks for those jndi prefixes.

This is arguably a DROP bug, but there is no reason to wrap one DROP instance in another as far as I can see.