### PR TITLE
Syncope Core updates, Move to Postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ target/
 
 /auth-database/nbactions-cida-auth-liquibase-local.xml
 tcp/
+/auth-manager/auth-manager-core/src/main/webapp/META-INF/context.xml
+/auth-manager/auth-manager-console/src/main/webapp/META-INF/context.xml

--- a/auth-manager/auth-manager-console/pom.xml
+++ b/auth-manager/auth-manager-console/pom.xml
@@ -19,7 +19,7 @@
 		<version>1.1.9-SNAPSHOT</version>
 	</parent>
 
-	<name>CIDA/Oracle build of Apache Syncope Console</name>
+	<name>CIDA build of Apache Syncope Console</name>
 	<description>
 		CIDA overlays some spring configuration files which look at JNDI properties instead of property files.
 		This allows us to reconfigure servers using JNDI instead of rebuilding the application.

--- a/auth-manager/auth-manager-console/src/main/resources/configuration.properties
+++ b/auth-manager/auth-manager-console/src/main/resources/configuration.properties
@@ -1,7 +1,3 @@
 # CIDA Overlay, CIDA version does NOT use the properties below, instead use JNDI property auth.manager.core.rest.url
 # and provide the full URL. Also need to provide a value to be placed in teh header of requests for host, auth.manager.core.host.
 # See applicationContext.xml.
-#scheme=http
-#host=localhost
-#port=8080
-#rootPath=/syncope/rest/

--- a/auth-manager/auth-manager-core/README.md
+++ b/auth-manager/auth-manager-core/README.md
@@ -1,0 +1,30 @@
+#### Build/Deploy Tips
+
+## Container Configuration
+When using Postgres JNDI resource block, ensure that you are setting `defaultAutoCommit` to `true`. Not doing so will cause Syncope to be unable to create the tables it needs to function.
+
+Local Docker example:
+```
+<Resource
+	description="token storage database"
+	name="jdbc/cidaAuthDS"
+	auth="Container"
+	type="javax.sql.DataSource"
+	username="postgres"
+	password="postgres"
+	driverClassName="org.postgresql.Driver"
+	url="jdbc:postgresql://192.168.99.100:5432/postgres"
+	maxActive="50"
+	maxIdle="10"
+	removeAbandoned="true"
+	removeAbandonedTimeout="60"
+	logAbandoned="true"
+	testOnBorrow="true"
+	defaultAutoCommit="true"
+	validationQuery="SELECT 1"
+	accessToUnderlyingConnectionAllowed="true"
+	jdbcInterceptors="org.apache.tomcat.jdbc.pool.interceptor.ConnectionState;org.apache.tomcat.jdbc.pool.interceptor.StatementFinalizer"
+	poolPreparedStatements="true"
+	maxOpenPreparedStatements="400"
+/>
+```

--- a/auth-manager/auth-manager-core/pom.xml
+++ b/auth-manager/auth-manager-core/pom.xml
@@ -61,16 +61,10 @@
 			<artifactId>jstl</artifactId>
 			<version>1.2</version>
 		</dependency>
-
 		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-web</artifactId>
-			<version>3.1.6.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-config</artifactId>
-			<version>3.1.6.RELEASE</version>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>9.4.1208.jre7</version>
 		</dependency>
 	</dependencies>
 

--- a/auth-manager/auth-manager-core/pom.xml
+++ b/auth-manager/auth-manager-core/pom.xml
@@ -19,7 +19,7 @@
 		<version>1.1.9-SNAPSHOT</version>
 	</parent>
 
-	<name>CIDA/Oracle build of Apache Syncope Core</name>
+	<name>CIDA build of Apache Syncope Core</name>
 	<description>
 		CIDA overlays some spring configuration files which look at JNDI properties instead of property files.
 		This allows us to reconfigure servers using JNDI instead of rebuilding the application.

--- a/auth-manager/auth-manager-core/src/main/resources/persistence.properties
+++ b/auth-manager/auth-manager-core/src/main/resources/persistence.properties
@@ -1,7 +1,7 @@
-jpa.driverClassName=oracle.jdbc.OracleDriver
-jpa.dialect=org.apache.openjpa.jdbc.sql.OracleDictionary
+jpa.driverClassName=org.postgresql.Driver
+jpa.dialect=org.apache.openjpa.jdbc.sql.PostgresDictionary
 jpa.pool.validationQuery=SELECT 1
 #note: other connection pool settings can also be configured here, see persistenceContext.xml
-quartz.jobstore=org.quartz.impl.jdbcjobstore.oracle.OracleDelegate
-quartz.sql=tables_oracle.sql
-logback.sql=oracle.sql
+quartz.jobstore=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+quartz.sql=tables_postgres.sql
+logback.sql=postgresql.sql

--- a/auth-manager/auth-manager-core/src/main/webapp/WEB-INF/web.xml
+++ b/auth-manager/auth-manager-core/src/main/webapp/WEB-INF/web.xml
@@ -78,7 +78,7 @@
 		<auth-method>CLIENT-CERT</auth-method>
 	</login-config>
 	<resource-ref>
-		<res-ref-name>jdbc/syncopeDataSource</res-ref-name>
+		<res-ref-name>jdbc/cidaAuthDS</res-ref-name>
 		<res-type>javax.sql.DataSource</res-type>
 		<res-auth>Container</res-auth>
 	</resource-ref>

--- a/auth-manager/pom.xml
+++ b/auth-manager/pom.xml
@@ -18,7 +18,7 @@
 		<version>1.1.9-SNAPSHOT</version>
 	</parent>
 
-	<name>CIDA/Oracle build of Apache Syncope</name>
+	<name>CIDA build of Apache Syncope</name>
 	<artifactId>auth-manager</artifactId>
 	<packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,16 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>ianal-maven-plugin</artifactId>
+					<version>1.0-alpha-1</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.rat</groupId>
+					<artifactId>apache-rat-plugin</artifactId>
+					<version>0.11</version>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.5.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<google.api.version>1.21.0</google.api.version>
 		<jersey.version>2.22.1</jersey.version>
-		<syncope.version>1.2.7</syncope.version>
+		<syncope.version>1.1.8</syncope.version>
 		<h2.version>1.4.191</h2.version>
 		<version.liquibase-maven-plugin>3.4.2</version.liquibase-maven-plugin>
 		<version.maven.failsafe.plugin>2.19.1</version.maven.failsafe.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<google.api.version>1.21.0</google.api.version>
 		<jersey.version>2.22.1</jersey.version>
-		<syncope.version>1.2.6</syncope.version>
+		<syncope.version>1.2.7</syncope.version>
 		<h2.version>1.4.191</h2.version>
 		<version.liquibase-maven-plugin>3.4.2</version.liquibase-maven-plugin>
 		<version.maven.failsafe.plugin>2.19.1</version.maven.failsafe.plugin>


### PR DESCRIPTION
- Reverted back to Syncope 1.1.x 
- Updated from Syncope 1.1.6 to 1.1.8
- Switched to using Postrges instead of Oracle
- Fixed override of web.xml to use correct jdbc JNDI resource name
- Removed Spring dependencies from Syncope core project
- Add PostGRES driver as a dependency to core