### PR TITLE
IAuthClient now throws a checked exception for failed logins

### DIFF
--- a/auth-client/src/main/java/gov/usgs/cida/auth/client/CachingAuthClient.java
+++ b/auth-client/src/main/java/gov/usgs/cida/auth/client/CachingAuthClient.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.security.auth.login.LoginException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -34,7 +35,7 @@ public class CachingAuthClient extends AuthClient {
 	/**
 	 * {@inheritDoc}
 	 */
-	public AuthToken getNewToken(String username, String password) {
+	public AuthToken getNewToken(String username, String password) throws LoginException {
 		AuthToken token = super.getNewToken(username, password);
 		if (token != null) {
 			tokenCache.put(token.getTokenId(), token);

--- a/auth-client/src/main/java/gov/usgs/cida/auth/client/IAuthClient.java
+++ b/auth-client/src/main/java/gov/usgs/cida/auth/client/IAuthClient.java
@@ -3,6 +3,7 @@ package gov.usgs.cida.auth.client;
 import java.util.List;
 
 import gov.usgs.cida.auth.model.AuthToken;
+import javax.security.auth.login.LoginException;
 
 /**
  * Provides methods which abstract the function of a cida-auth-webservice endpoint.
@@ -15,12 +16,23 @@ import gov.usgs.cida.auth.model.AuthToken;
 public interface IAuthClient {
 	
 	/**
-	 * Authenticates the username and password against a token service. Returns 
+	 * Authenticates the username and password against a token service.
+	 * 
+	 * If the user's credentials are invalid or incorrect, a LoginException is
+	 * thrown.
+	 * 
+	 * The underlying connection implementation may throw RuntimeExceptions
+	 * if the specified URL is unreachable or fails for some other reason.
+	 * These are generally of type javax.ws.rs.ClientErrorException or 
+	 * javax.ws.rs.ProcessingException - Catch these if you need to stop them
+	 * from percolating to the UI layer.
+	 * 
 	 * @param username
 	 * @param password
 	 * @return AuthToken
+	 * @throws javax.security.auth.login.LoginException If the user's credentials are invalid / incorrect
 	 */
-	public AuthToken getNewToken(String username, String password);
+	public AuthToken getNewToken(String username, String password) throws LoginException;
 	
 	/**
 	 * Returns a token that has the provided ID

--- a/auth-client/src/test/java/gov/usgs/cida/auth/client/AuthClientTest.java
+++ b/auth-client/src/test/java/gov/usgs/cida/auth/client/AuthClientTest.java
@@ -4,8 +4,11 @@ import gov.usgs.cida.auth.model.AuthToken;
 
 import java.net.URISyntaxException;
 import java.util.List;
+import javax.security.auth.login.LoginException;
 
 import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ProcessingException;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -28,7 +31,7 @@ public class AuthClientTest extends BaseClientTest{
 	}
 
 	@Test
-	public void testGetNewToken() throws URISyntaxException {
+	public void testGetNewToken() throws URISyntaxException, LoginException {
 		System.out.println("getNewToken");
 		String username = "testuser";
 		String password = "testpassword";
@@ -51,8 +54,12 @@ public class AuthClientTest extends BaseClientTest{
 		assertThat(result.get(1), is(equalTo("AUTH_LEVEL_TWO")));
 	}
 
-	@Test
-	public void testGetNewTokenWithErrorCode() throws URISyntaxException {
+	/**
+	 * This request is unprocessable b/c the server cannot be reached,
+	 * resulting in a RuntimeException (ProcessingException)
+	 */
+	@Test(expected=NotFoundException.class)
+	public void testGetNewTokenWithErrorCode() throws URISyntaxException, LoginException {
 		System.out.println("testGetNewTokenGetting401");
 		String username = "testuser";
 		String password = "testpassword";

--- a/auth-client/src/test/java/gov/usgs/cida/auth/client/CachingAuthClientTest.java
+++ b/auth-client/src/test/java/gov/usgs/cida/auth/client/CachingAuthClientTest.java
@@ -11,8 +11,10 @@ import static org.junit.Assert.assertTrue;
 import gov.usgs.cida.auth.model.AuthToken;
 
 import java.net.URISyntaxException;
+import javax.security.auth.login.LoginException;
 
 import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -31,9 +33,13 @@ public class CachingAuthClientTest extends AuthClientTest {
 		instance = new CachingAuthClient(authUrl);
 	}
 
-	@Test
+	/**
+	 * This request is unprocessable b/c the server cannot be reached,
+	 * resulting in a RuntimeException.
+	 */
+	@Test(expected=NotFoundException.class)
 	@Override
-	public void testGetNewToken() throws URISyntaxException {
+	public void testGetNewToken() throws URISyntaxException, LoginException {
 		super.testGetNewToken();
 		mockServer.reset(); //these stops the server from responding to requests
 		
@@ -49,14 +55,6 @@ public class CachingAuthClientTest extends AuthClientTest {
 		super.testGetRolesByToken();
 		mockServer.reset(); //these stops the server from responding to requests
 		super.testGetRolesByToken(); //tests should still pass
-	}
-
-	@Test
-	@Override
-	public void testGetNewTokenWithErrorCode() throws URISyntaxException {
-		super.testGetNewTokenWithErrorCode();
-		mockServer.reset(); //these stops the server from responding to requests
-		super.testGetNewTokenWithErrorCode(); //tests should still pass
 	}
 
 	@Test

--- a/auth-web-utils/src/main/java/gov/usgs/cida/auth/ws/rs/service/AuthTokenService.java
+++ b/auth-web-utils/src/main/java/gov/usgs/cida/auth/ws/rs/service/AuthTokenService.java
@@ -5,6 +5,7 @@ import gov.usgs.cida.auth.model.AuthToken;
 import gov.usgs.cida.auth.utils.HttpTokenUtils;
 
 import java.util.List;
+import javax.security.auth.login.LoginException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.NotAuthorizedException;
@@ -50,7 +51,7 @@ public class AuthTokenService {
 				LOG.warn("Failed to authenticate " + username);
 				response = Response.status(Response.Status.UNAUTHORIZED).build();
 			}
-		} catch(NotAuthorizedException ex) {
+		} catch(LoginException ex) {
 			response = Response.status(Response.Status.UNAUTHORIZED).build();
 		}
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<h2.version>1.4.191</h2.version>
 		<version.liquibase-maven-plugin>3.4.2</version.liquibase-maven-plugin>
 		<version.maven.failsafe.plugin>2.19.1</version.maven.failsafe.plugin>
-		<version.maven.surefire.plugin>2.19.1</version.maven.surefire.plugin>
+		<version.maven.surefire.plugin>2.18.1</version.maven.surefire.plugin>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
******* This is an incompatible change for applications directly using the IAuthClient interface ***
Previously users of IAuthClient.getNewToken() needed to catch a NotAuthorizedException(a RuntimeException) in order to detect a failed login.  Since this is a non-ignorable exception, it is now a checked exception (LoginExcpetion).

Also, other types of RuntimeExceptions that happen during the attempt to validate the user against a remote service are now passed through to the caller of getNewToken().  Previously they were all swallowed by the call. This will result in some RuntimeErrors being passed higher up the chain in some
apps.  Existing tests had to be changed because a bad url now throws an NotFoundException instead of just returning a null token.

All application uses of IAuthClient.getNewToken() will need to be reviewed as a result of this change.
*******

* Added a checked exception for getNewToken()
* No longer swallowing ClientErrorException in getNewToken(), which was a catch-all for all other types of error that could happen, including bad urls, unavailable servers, bad certs, etc..
* Improved docs for getNewToken()
* Downgraded the surefire plugin from 2.19.1 to 2.18.1 to bypass a bug in NetBeans
where 2.19.1 will not show the JUnit test window:
https://netbeans.org/bugzilla/show_bug.cgi?id=257563