### PR TITLE
Removed the "test" scope from a liquibase update set for Postgres/H2

### DIFF
--- a/auth-database/src/main/resources/liquibase/changelog/create/changelog-create-token-table.xml
+++ b/auth-database/src/main/resources/liquibase/changelog/create/changelog-create-token-table.xml
@@ -55,7 +55,7 @@
 		</rollback>
 	</changeSet>
 	
-	<changeSet author="${runasusername}" id="add-non-oracle-autonumber" context="test" dbms="h2,postgresql">
+	<changeSet author="${runasusername}" id="add-non-oracle-autonumber" dbms="h2,postgresql">
 		<addAutoIncrement 
 			columnDataType="BIGINT"
 			columnName="ID"


### PR DESCRIPTION
This allows us to fully use Postgres in a non-test, production ready context